### PR TITLE
use correct framework

### DIFF
--- a/Reecon.csproj
+++ b/Reecon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	  <TargetFramework>net80</TargetFramework>
+	  <TargetFramework>net8.0</TargetFramework>
 	  <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	  <StartupObject>Reecon.Program</StartupObject>
 	  <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)